### PR TITLE
BP-561: Added deadletter logs integration

### DIFF
--- a/packages/ppbgdi/changelog.yml
+++ b/packages/ppbgdi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Added deadletter integration
+      type: enhancement
+      link: https://github.com/geoadmin/infra-elastic-integrations/pull/17
 - version: "0.4.0"
   changes:
     - description: Added ppbgdi cloudfront integration

--- a/packages/ppbgdi/data_stream/deadletter_logs/fields/base-fields.yml
+++ b/packages/ppbgdi/data_stream/deadletter_logs/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/packages/ppbgdi/data_stream/deadletter_logs/manifest.yml
+++ b/packages/ppbgdi/data_stream/deadletter_logs/manifest.yml
@@ -1,0 +1,2 @@
+title: "Deadletter logs"
+type: logs

--- a/packages/ppbgdi/manifest.yml
+++ b/packages/ppbgdi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.1
 name: ppbgdi
 title: "PPBGDI"
-version: 0.4.0
+version: 0.5.0
 source:
   license: "Apache-2.0"
 description: "Collect logs and metrics from PPBGDI, via kubernetes or Elastic Agent"


### PR DESCRIPTION
Added deadletter integration, mainly for elastic serverless forwarder.

As of esf version 1.17.0, documents with ingestion errors can be sent to a dealetter index/datastream for analysis.
