### PR TITLE
PB-1714: Added kubernetes otel dashboard

### DIFF
--- a/packages/ppbgdi/README.md
+++ b/packages/ppbgdi/README.md
@@ -41,7 +41,7 @@ Dashboards which are created or edited can be exported to this package with the 
 # Observability dev cluster
 summon -p ssm -e bgdi-observability-dev elastic-package export dashboards --id <dashboard-id>
 
-# Observability dev cluster
+# Observability prod cluster
 summon -p ssm -e bgdi-observability-prod elastic-package export dashboards --id <dashboard-id>
 
 ```
@@ -75,7 +75,7 @@ Managed dashboards can not be edited. To make them editable, use the following c
 # Observability dev cluster
 summon -p ssm -e bgdi-observability-dev elastic-package edit dashboards --id <dashboard-id>
 
-# Observability dev cluster
+# Observability prod cluster
 summon -p ssm -e bgdi-observability-prod elastic-package edit dashboards --id <dashboard-id>
 
 ```

--- a/packages/ppbgdi/changelog.yml
+++ b/packages/ppbgdi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Added kubernetes otel overwiew dashboard
+      type: enhancement
+      link: https://github.com/geoadmin/infra-elastic-integrations/pull/44
 - version: "1.6.2"
   changes:
     - description: Fix lambda_logs data_stream pipeline and tests

--- a/packages/ppbgdi/kibana/dashboard/ppbgdi-cfe0d27f-b390-4585-8910-78953e0bd447.json
+++ b/packages/ppbgdi/kibana/dashboard/ppbgdi-cfe0d27f-b390-4585-8910-78953e0bd447.json
@@ -1,0 +1,5811 @@
+{
+    "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {
+                "a040080e-8a63-4000-85fa-59cc2e48067d": {
+                    "explicitInput": {
+                        "dataViewId": "metrics-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "resource.attributes.k8s.node.name",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "Node"
+                    },
+                    "grow": false,
+                    "order": 1,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "d0079981-006d-4357-aed8-a05eef49b2eb": {
+                    "explicitInput": {
+                        "dataViewId": "metrics-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "resource.attributes.k8s.namespace.name",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "Namespace"
+                    },
+                    "grow": false,
+                    "order": 2,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "fc4570df-08ee-4629-85db-901b3008f61a": {
+                    "explicitInput": {
+                        "dataViewId": "metrics-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "resource.attributes.k8s.cluster.name",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "Cluster"
+                    },
+                    "grow": false,
+                    "order": 0,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                }
+            },
+            "showApplySelections": false
+        },
+        "description": "",
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "#### Cluster overview",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "4c6a97eb-f6ea-4690-b9e7-02227b9a54ed",
+                    "w": 5,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "4c6a97eb-f6ea-4690-b9e7-02227b9a54ed",
+                "type": "visualization"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "894781bd-2933-418c-b883-1f758794a45d": {
+                                            "columnOrder": [
+                                                "9f666c7c-11a0-4b4f-8491-981adca1e288"
+                                            ],
+                                            "columns": {
+                                                "9f666c7c-11a0-4b4f-8491-981adca1e288": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "resource.attributes.k8s.node.name: * "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Nodes",
+                                                    "operationType": "unique_count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "resource.attributes.k8s.node.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "resource.attributes.k8s.node.name",
+                                        "index": "fdeb2ffb-0593-4286-9b7d-b259c948f145",
+                                        "key": "resource.attributes.k8s.node.name",
+                                        "negate": false,
+                                        "type": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "resource.attributes.k8s.node.name"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "layerId": "894781bd-2933-418c-b883-1f758794a45d",
+                                "layerType": "data",
+                                "metricAccessor": "9f666c7c-11a0-4b4f-8491-981adca1e288"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.node.name",
+                                "index": "fdeb2ffb-0593-4286-9b7d-b259c948f145",
+                                "key": "resource.attributes.k8s.node.name",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.node.name"
+                                }
+                            }
+                        }
+                    ],
+                    "hidePanelTitles": true,
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": ""
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "62b7952e-3465-4519-9d4a-eb8c90cbb09d",
+                    "w": 8,
+                    "x": 5,
+                    "y": 0
+                },
+                "panelIndex": "62b7952e-3465-4519-9d4a-eb8c90cbb09d",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "54494aa2-197e-42d6-a8ef-0072655ca351": {
+                                            "columnOrder": [
+                                                "64b457c8-4cd3-4b42-8c44-6b096a74e8c6",
+                                                "e601a669-92b3-4d8b-9c4a-1f94404bd418",
+                                                "78343ebd-0b27-4de8-9d57-698df9a0e134",
+                                                "54c28451-89d7-40e5-9f2e-6aba9c66cf2e"
+                                            ],
+                                            "columns": {
+                                                "54c28451-89d7-40e5-9f2e-6aba9c66cf2e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.container.cpu_limit\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Limits",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": ""
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.container.cpu_limit"
+                                                },
+                                                "64b457c8-4cd3-4b42-8c44-6b096a74e8c6": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of resource.attributes.container.id",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "78343ebd-0b27-4de8-9d57-698df9a0e134",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.container.id"
+                                                },
+                                                "78343ebd-0b27-4de8-9d57-698df9a0e134": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.container.cpu_request\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Requests",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": ""
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.container.cpu_request"
+                                                },
+                                                "e601a669-92b3-4d8b-9c4a-1f94404bd418": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "linkToLayers": [],
+                                            "sampling": 1
+                                        },
+                                        "dba09ccc-6ec6-443b-8620-1eac10077772": {
+                                            "columnOrder": [
+                                                "4b0797fb-7701-470c-9c3e-e83d9e8b28a2",
+                                                "4f5b2210-09f1-4100-a1d3-c34698bf7bc3",
+                                                "3d67042a-4b44-4761-bf96-dc4ead89fb26"
+                                            ],
+                                            "columns": {
+                                                "3d67042a-4b44-4761-bf96-dc4ead89fb26": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.node.allocatable_cpu\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Allocatable",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 1,
+                                                                "suffix": ""
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "",
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.allocatable_cpu"
+                                                },
+                                                "4b0797fb-7701-470c-9c3e-e83d9e8b28a2": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of resource.attributes.k8s.node.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "3d67042a-4b44-4761-bf96-dc4ead89fb26",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.node.name"
+                                                },
+                                                "4f5b2210-09f1-4100-a1d3-c34698bf7bc3": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": true,
+                                    "yRight": false
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": false
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "3d67042a-4b44-4761-bf96-dc4ead89fb26"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "dba09ccc-6ec6-443b-8620-1eac10077772",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "4b0797fb-7701-470c-9c3e-e83d9e8b28a2",
+                                        "xAccessor": "4f5b2210-09f1-4100-a1d3-c34698bf7bc3"
+                                    },
+                                    {
+                                        "accessors": [
+                                            "78343ebd-0b27-4de8-9d57-698df9a0e134",
+                                            "54c28451-89d7-40e5-9f2e-6aba9c66cf2e"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "54494aa2-197e-42d6-a8ef-0072655ca351",
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "splitAccessor": "64b457c8-4cd3-4b42-8c44-6b096a74e8c6",
+                                        "xAccessor": "e601a669-92b3-4d8b-9c4a-1f94404bd418"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": false
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": "Cores"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "CPU Usage"
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "39dd2546-a07a-49e5-a432-5e1b64b6cb13",
+                    "w": 18,
+                    "x": 13,
+                    "y": 0
+                },
+                "panelIndex": "39dd2546-a07a-49e5-a432-5e1b64b6cb13",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "54494aa2-197e-42d6-a8ef-0072655ca351": {
+                                            "columnOrder": [
+                                                "64b457c8-4cd3-4b42-8c44-6b096a74e8c6",
+                                                "e601a669-92b3-4d8b-9c4a-1f94404bd418",
+                                                "78343ebd-0b27-4de8-9d57-698df9a0e134",
+                                                "c824d876-14dd-4d05-a4f8-52bc9c894ee4"
+                                            ],
+                                            "columns": {
+                                                "64b457c8-4cd3-4b42-8c44-6b096a74e8c6": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of resource.attributes.container.id",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "78343ebd-0b27-4de8-9d57-698df9a0e134",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.container.id"
+                                                },
+                                                "78343ebd-0b27-4de8-9d57-698df9a0e134": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.container.memory_request\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Requests",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.container.memory_request"
+                                                },
+                                                "c824d876-14dd-4d05-a4f8-52bc9c894ee4": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.container.memory_limit\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Limits",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.container.memory_limit"
+                                                },
+                                                "e601a669-92b3-4d8b-9c4a-1f94404bd418": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "linkToLayers": [],
+                                            "sampling": 1
+                                        },
+                                        "dba09ccc-6ec6-443b-8620-1eac10077772": {
+                                            "columnOrder": [
+                                                "4b0797fb-7701-470c-9c3e-e83d9e8b28a2",
+                                                "4f5b2210-09f1-4100-a1d3-c34698bf7bc3",
+                                                "3d67042a-4b44-4761-bf96-dc4ead89fb26"
+                                            ],
+                                            "columns": {
+                                                "3d67042a-4b44-4761-bf96-dc4ead89fb26": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.node.allocatable_memory\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Allocatable",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "",
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.allocatable_memory"
+                                                },
+                                                "4b0797fb-7701-470c-9c3e-e83d9e8b28a2": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of resource.attributes.k8s.node.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "3d67042a-4b44-4761-bf96-dc4ead89fb26",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.node.name"
+                                                },
+                                                "4f5b2210-09f1-4100-a1d3-c34698bf7bc3": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": true,
+                                    "yRight": false
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": false
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "3d67042a-4b44-4761-bf96-dc4ead89fb26"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "dba09ccc-6ec6-443b-8620-1eac10077772",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "4b0797fb-7701-470c-9c3e-e83d9e8b28a2",
+                                        "xAccessor": "4f5b2210-09f1-4100-a1d3-c34698bf7bc3"
+                                    },
+                                    {
+                                        "accessors": [
+                                            "78343ebd-0b27-4de8-9d57-698df9a0e134",
+                                            "c824d876-14dd-4d05-a4f8-52bc9c894ee4"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "54494aa2-197e-42d6-a8ef-0072655ca351",
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "splitAccessor": "64b457c8-4cd3-4b42-8c44-6b096a74e8c6",
+                                        "xAccessor": "e601a669-92b3-4d8b-9c4a-1f94404bd418"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": false
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": "Bytes"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Memory Usage"
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "f338dd4f-f6a0-4ef3-a9cb-2ec7a3894415",
+                    "w": 17,
+                    "x": 31,
+                    "y": 0
+                },
+                "panelIndex": "f338dd4f-f6a0-4ef3-a9cb-2ec7a3894415",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "894781bd-2933-418c-b883-1f758794a45d": {
+                                            "columnOrder": [
+                                                "9f666c7c-11a0-4b4f-8491-981adca1e288"
+                                            ],
+                                            "columns": {
+                                                "9f666c7c-11a0-4b4f-8491-981adca1e288": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Namespaces",
+                                                    "operationType": "unique_count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "resource.attributes.k8s.namespace.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "resource.attributes.k8s.namespace.name",
+                                        "index": "d632b895-3242-4f49-8d2c-ea7310b23b9a",
+                                        "key": "resource.attributes.k8s.namespace.name",
+                                        "negate": false,
+                                        "type": "exists",
+                                        "value": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "resource.attributes.k8s.namespace.name"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "layerId": "894781bd-2933-418c-b883-1f758794a45d",
+                                "layerType": "data",
+                                "metricAccessor": "9f666c7c-11a0-4b4f-8491-981adca1e288"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.namespace.name",
+                                "index": "d632b895-3242-4f49-8d2c-ea7310b23b9a",
+                                "key": "resource.attributes.k8s.namespace.name",
+                                "negate": false,
+                                "type": "exists",
+                                "value": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.namespace.name"
+                                }
+                            }
+                        }
+                    ],
+                    "hidePanelTitles": true,
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": ""
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "95e20a83-c9b8-4046-a479-605870bf7a21",
+                    "w": 8,
+                    "x": 5,
+                    "y": 4
+                },
+                "panelIndex": "95e20a83-c9b8-4046-a479-605870bf7a21",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "description": "",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "hidePanelTitles": true,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "#### Node overview",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    },
+                    "title": ""
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "cb8d1275-f1a5-4c35-8eb2-988c8855735f",
+                    "w": 5,
+                    "x": 0,
+                    "y": 8
+                },
+                "panelIndex": "cb8d1275-f1a5-4c35-8eb2-988c8855735f",
+                "type": "visualization"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "b5e4cee3-e558-4805-b276-673a7ebff8f0": {
+                                            "columnOrder": [
+                                                "f9871fa4-fd08-4774-b70f-4420e25bfa10",
+                                                "225c46db-da40-46b5-be76-59b23900b34e",
+                                                "bf34d967-002f-4217-8a9e-ab5dceeb577f"
+                                            ],
+                                            "columns": {
+                                                "225c46db-da40-46b5-be76-59b23900b34e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "metrics.k8s.node.condition_ready: 1"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ready",
+                                                    "operationType": "unique_count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.condition_ready"
+                                                },
+                                                "bf34d967-002f-4217-8a9e-ab5dceeb577f": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "metrics.k8s.node.condition_ready\u003c 1"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Not ready",
+                                                    "operationType": "unique_count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.condition_ready"
+                                                },
+                                                "f9871fa4-fd08-4774-b70f-4420e25bfa10": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of resource.attributes.k8s.node.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "225c46db-da40-46b5-be76-59b23900b34e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.node.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "metrics.k8s.node.condition_ready",
+                                        "index": "eb5475c8-e2ca-4480-981d-38ddebecb0d8",
+                                        "key": "metrics.k8s.node.condition_ready",
+                                        "negate": false,
+                                        "type": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "metrics.k8s.node.condition_ready"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "allowMultipleMetrics": true,
+                                        "categoryDisplay": "default",
+                                        "collapseFns": {
+                                            "f9871fa4-fd08-4774-b70f-4420e25bfa10": "sum"
+                                        },
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorsByDimension": {
+                                            "bf34d967-002f-4217-8a9e-ab5dceeb577f": "#e7664c"
+                                        },
+                                        "layerId": "b5e4cee3-e558-4805-b276-673a7ebff8f0",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "metrics": [
+                                            "225c46db-da40-46b5-be76-59b23900b34e",
+                                            "bf34d967-002f-4217-8a9e-ab5dceeb577f"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "value",
+                                        "primaryGroups": [
+                                            "f9871fa4-fd08-4774-b70f-4420e25bfa10"
+                                        ]
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.node.condition_ready",
+                                "index": "eb5475c8-e2ca-4480-981d-38ddebecb0d8",
+                                "key": "metrics.k8s.node.condition_ready",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.node.condition_ready"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Nodes Status"
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "ce370870-81e2-4649-acc2-fddcae3686dc",
+                    "w": 8,
+                    "x": 5,
+                    "y": 8
+                },
+                "panelIndex": "ce370870-81e2-4649-acc2-fddcae3686dc",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "f494e875-7646-4748-b9d8-e4120c00e866": {
+                                            "columnOrder": [
+                                                "bf28e529-3f60-4c01-9b8b-7b7a51c72b33",
+                                                "71507b5a-60f2-491e-8774-ae2b88424b9b",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162d",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX2",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX1",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX0"
+                                            ],
+                                            "columns": {
+                                                "71507b5a-60f2-491e-8774-ae2b88424b9b": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162d": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "CPU Utilization",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "last_value(metrics.k8s.node.cpu.usage)/last_value(metrics.k8s.node.allocatable_cpu)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "95e56b61-fe65-4ac4-81aa-d9608a43162dX2"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.node.cpu.usage\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of CPU Usage",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.cpu.usage"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.node.allocatable_cpu\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of CPU Usage",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.allocatable_cpu"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of CPU Usage",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX0",
+                                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX1"
+                                                            ],
+                                                            "location": {
+                                                                "max": 83,
+                                                                "min": 0
+                                                            },
+                                                            "name": "divide",
+                                                            "text": "last_value(metrics.k8s.node.cpu.usage)/last_value(metrics.k8s.node.allocatable_cpu)",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "95e56b61-fe65-4ac4-81aa-d9608a43162dX0",
+                                                        "95e56b61-fe65-4ac4-81aa-d9608a43162dX1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "bf28e529-3f60-4c01-9b8b-7b7a51c72b33": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of resource.attributes.k8s.node.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.node.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "resource.attributes.k8s.node.name",
+                                        "index": "6f2e38ed-8fa8-426f-a951-2b138654a71e",
+                                        "key": "resource.attributes.k8s.node.name",
+                                        "negate": false,
+                                        "type": "exists",
+                                        "value": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "resource.attributes.k8s.node.name"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "95e56b61-fe65-4ac4-81aa-d9608a43162d"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "f494e875-7646-4748-b9d8-e4120c00e866",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area",
+                                        "showGridlines": false,
+                                        "splitAccessor": "bf28e529-3f60-4c01-9b8b-7b7a51c72b33",
+                                        "xAccessor": "71507b5a-60f2-491e-8774-ae2b88424b9b"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "shouldTruncate": false,
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "area",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": "% CPU"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.node.name",
+                                "index": "6f2e38ed-8fa8-426f-a951-2b138654a71e",
+                                "key": "resource.attributes.k8s.node.name",
+                                "negate": false,
+                                "type": "exists",
+                                "value": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.node.name"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Top CPU intensive Nodes"
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "b618f38b-8aa4-459a-89dc-eab8b4f6d1a7",
+                    "w": 12,
+                    "x": 13,
+                    "y": 8
+                },
+                "panelIndex": "b618f38b-8aa4-459a-89dc-eab8b4f6d1a7",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "As a ratio of a node working_set to the total node allocatable memory",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "f494e875-7646-4748-b9d8-e4120c00e866": {
+                                            "columnOrder": [
+                                                "bf28e529-3f60-4c01-9b8b-7b7a51c72b33",
+                                                "71507b5a-60f2-491e-8774-ae2b88424b9b",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162d",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX2",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX1",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX0"
+                                            ],
+                                            "columns": {
+                                                "71507b5a-60f2-491e-8774-ae2b88424b9b": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162d": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Memory Utilization",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "last_value(metrics.k8s.node.memory.working_set)/last_value(metrics.k8s.node.allocatable_memory)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "95e56b61-fe65-4ac4-81aa-d9608a43162dX2"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.node.memory.working_set\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of Memory Utilization",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.memory.working_set"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.node.allocatable_memory\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of Memory Utilization",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.allocatable_memory"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Memory Utilization",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX0",
+                                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX1"
+                                                            ],
+                                                            "location": {
+                                                                "max": 95,
+                                                                "min": 0
+                                                            },
+                                                            "name": "divide",
+                                                            "text": "last_value(metrics.k8s.node.memory.working_set)/last_value(metrics.k8s.node.allocatable_memory)",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "95e56b61-fe65-4ac4-81aa-d9608a43162dX0",
+                                                        "95e56b61-fe65-4ac4-81aa-d9608a43162dX1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "bf28e529-3f60-4c01-9b8b-7b7a51c72b33": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of resource.attributes.k8s.node.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.node.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "resource.attributes.k8s.node.name",
+                                        "index": "654da27d-a112-4dad-99c1-c5c33f5faaa1",
+                                        "key": "resource.attributes.k8s.node.name",
+                                        "negate": false,
+                                        "type": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "resource.attributes.k8s.node.name"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "95e56b61-fe65-4ac4-81aa-d9608a43162d"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "f494e875-7646-4748-b9d8-e4120c00e866",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area",
+                                        "showGridlines": false,
+                                        "splitAccessor": "bf28e529-3f60-4c01-9b8b-7b7a51c72b33",
+                                        "xAccessor": "71507b5a-60f2-491e-8774-ae2b88424b9b"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "shouldTruncate": false,
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "area",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": "% Memory"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "As a ratio of a node working_set to the total node allocatable memory",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.node.name",
+                                "index": "654da27d-a112-4dad-99c1-c5c33f5faaa1",
+                                "key": "resource.attributes.k8s.node.name",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.node.name"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Top Memory intensive Nodes"
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "1f8d34d9-bad8-41fc-8812-087281430b3a",
+                    "w": 12,
+                    "x": 25,
+                    "y": 8
+                },
+                "panelIndex": "1f8d34d9-bad8-41fc-8812-087281430b3a",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "1b04b540-39ae-4cfd-8088-34a4bf3d5654",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "f494e875-7646-4748-b9d8-e4120c00e866": {
+                                            "columnOrder": [
+                                                "bf28e529-3f60-4c01-9b8b-7b7a51c72b33",
+                                                "71507b5a-60f2-491e-8774-ae2b88424b9b",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162d",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX2",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX1",
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX0"
+                                            ],
+                                            "columns": {
+                                                "71507b5a-60f2-491e-8774-ae2b88424b9b": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162d": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Filesystem Utilization",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "last_value(metrics.k8s.node.filesystem.usage)/last_value(metrics.k8s.node.filesystem.capacity)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "95e56b61-fe65-4ac4-81aa-d9608a43162dX2"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.node.filesystem.usage\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of Filesystem Utilization",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.filesystem.usage"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.node.filesystem.capacity\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of Filesystem Utilization",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.node.filesystem.capacity"
+                                                },
+                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Filesystem Utilization",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX0",
+                                                                "95e56b61-fe65-4ac4-81aa-d9608a43162dX1"
+                                                            ],
+                                                            "location": {
+                                                                "max": 94,
+                                                                "min": 0
+                                                            },
+                                                            "name": "divide",
+                                                            "text": "last_value(metrics.k8s.node.filesystem.usage)/last_value(metrics.k8s.node.filesystem.capacity)",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "95e56b61-fe65-4ac4-81aa-d9608a43162dX0",
+                                                        "95e56b61-fe65-4ac4-81aa-d9608a43162dX1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "bf28e529-3f60-4c01-9b8b-7b7a51c72b33": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of resource.attributes.k8s.node.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.node.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "resource.attributes.k8s.node.name",
+                                        "index": "1b04b540-39ae-4cfd-8088-34a4bf3d5654",
+                                        "key": "resource.attributes.k8s.node.name",
+                                        "negate": false,
+                                        "type": "exists",
+                                        "value": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "resource.attributes.k8s.node.name"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "95e56b61-fe65-4ac4-81aa-d9608a43162d"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "f494e875-7646-4748-b9d8-e4120c00e866",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area",
+                                        "showGridlines": false,
+                                        "splitAccessor": "bf28e529-3f60-4c01-9b8b-7b7a51c72b33",
+                                        "xAccessor": "71507b5a-60f2-491e-8774-ae2b88424b9b"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "shouldTruncate": false,
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "area",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": "% FS usage"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.node.name",
+                                "index": "1b04b540-39ae-4cfd-8088-34a4bf3d5654",
+                                "key": "resource.attributes.k8s.node.name",
+                                "negate": false,
+                                "type": "exists",
+                                "value": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.node.name"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Top Filesystem Utilization intensive Nodes"
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "a45c94ad-f7e4-47f6-9da8-f77a2e0540b4",
+                    "w": 11,
+                    "x": 37,
+                    "y": 8
+                },
+                "panelIndex": "a45c94ad-f7e4-47f6-9da8-f77a2e0540b4",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "hidePanelTitles": true,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "#### Workload overview\n",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "e82ffc5c-9aa1-4f16-96ef-af1e1ec7bae5",
+                    "w": 48,
+                    "x": 0,
+                    "y": 16
+                },
+                "panelIndex": "e82ffc5c-9aa1-4f16-96ef-af1e1ec7bae5",
+                "type": "visualization"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "0e11ca27-40f5-4300-b885-17ade4895220",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "57a8eb42-6f2c-4112-9d6c-c03d982c569e": {
+                                            "columnOrder": [
+                                                "1bbad376-8c0e-4e9a-ba22-ecd1b9b9fdd6",
+                                                "5f8b6083-6bae-4fe5-936e-1b63ca6cb92f",
+                                                "39029a76-ce62-4fdf-aa1a-3cbe8e71548f",
+                                                "937359b3-a626-4ac7-84c8-0e181d807bc5"
+                                            ],
+                                            "columns": {
+                                                "1bbad376-8c0e-4e9a-ba22-ecd1b9b9fdd6": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of resource.attributes.k8s.container.status.last_terminated_reason + 1 other",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "resource.attributes.k8s.pod.name"
+                                                        ],
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.container.status.last_terminated_reason"
+                                                },
+                                                "39029a76-ce62-4fdf-aa1a-3cbe8e71548f": {
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.container.restarts\" :*"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Differences of Restarts",
+                                                    "operationType": "differences",
+                                                    "references": [
+                                                        "937359b3-a626-4ac7-84c8-0e181d807bc5"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "5f8b6083-6bae-4fe5-936e-1b63ca6cb92f": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "937359b3-a626-4ac7-84c8-0e181d807bc5": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Restarts",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.container.restarts"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "resource.attributes.k8s.container.status.last_terminated_reason",
+                                        "index": "0e11ca27-40f5-4300-b885-17ade4895220",
+                                        "key": "resource.attributes.k8s.container.status.last_terminated_reason",
+                                        "negate": false,
+                                        "type": "exists",
+                                        "value": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "resource.attributes.k8s.container.status.last_terminated_reason"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel AND metrics.k8s.container.restarts \u003e 0"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "hideEndzones": true,
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "39029a76-ce62-4fdf-aa1a-3cbe8e71548f"
+                                        ],
+                                        "collapseFn": "",
+                                        "layerId": "57a8eb42-6f2c-4112-9d6c-c03d982c569e",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "1bbad376-8c0e-4e9a-ba22-ecd1b9b9fdd6",
+                                        "xAccessor": "5f8b6083-6bae-4fe5-936e-1b63ca6cb92f"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "No values in specific Visualisation means that no Pod restarts took place for the specific time range",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "resource.attributes.k8s.container.status.last_terminated_reason",
+                                "index": "0e11ca27-40f5-4300-b885-17ade4895220",
+                                "key": "resource.attributes.k8s.container.status.last_terminated_reason",
+                                "negate": false,
+                                "type": "exists",
+                                "value": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "resource.attributes.k8s.container.status.last_terminated_reason"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel AND metrics.k8s.container.restarts \u003e 0"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Container Restarts by Pod and Reason"
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "15285038-9ec2-4e24-858c-6713dba71e32",
+                    "w": 11,
+                    "x": 0,
+                    "y": 20
+                },
+                "panelIndex": "15285038-9ec2-4e24-858c-6713dba71e32",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "8d049466-cdf2-4c5b-97e3-8e3020b31c2a": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "8d049466-cdf2-4c5b-97e3-8e3020b31c2a",
+                                    "name": "pod-status-ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "failed": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('metrics.k8s.pod.phase')){ if (doc['metrics.k8s.pod.phase'].value == 4 ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "pending": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('metrics.k8s.pod.phase')){ if (doc['metrics.k8s.pod.phase'].value == 1 ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "running": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('metrics.k8s.pod.phase')){ if (doc['metrics.k8s.pod.phase'].value == 2 ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "succeeded": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('metrics.k8s.pod.phase')){ if (doc['metrics.k8s.pod.phase'].value == 3 ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "unknown": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('metrics.k8s.pod.phase')){ if (doc['metrics.k8s.pod.phase'].value == 5 ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*otel*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "bc4e65cf-0329-4ef1-ab2c-9b65e1d51af2": {
+                                            "columnOrder": [
+                                                "612663d3-a04c-454f-8463-6a902020d937",
+                                                "f71aa1e3-660e-42ff-93df-4d0c07361cad",
+                                                "50044e05-4069-4b17-9eeb-1f660804f30c",
+                                                "0c220bec-d606-4d63-a9a3-76ad54d82579",
+                                                "7f02e9ad-00e6-4b08-bd65-d52691a1f69e"
+                                            ],
+                                            "columns": {
+                                                "0c220bec-d606-4d63-a9a3-76ad54d82579": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"pending\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Pending",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "pending"
+                                                },
+                                                "50044e05-4069-4b17-9eeb-1f660804f30c": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"succeeded\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Succeeded",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "succeeded"
+                                                },
+                                                "612663d3-a04c-454f-8463-6a902020d937": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 1000 values of resource.attributes.k8s.pod.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f71aa1e3-660e-42ff-93df-4d0c07361cad",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 1000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.pod.name"
+                                                },
+                                                "7f02e9ad-00e6-4b08-bd65-d52691a1f69e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"failed\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Failed",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "failed"
+                                                },
+                                                "f71aa1e3-660e-42ff-93df-4d0c07361cad": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"running\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Running",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "running"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "metrics.k8s.pod.phase",
+                                        "index": "8d049466-cdf2-4c5b-97e3-8e3020b31c2a",
+                                        "key": "metrics.k8s.pod.phase",
+                                        "negate": false,
+                                        "type": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "metrics.k8s.pod.phase"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [
+                                {
+                                    "id": "8d049466-cdf2-4c5b-97e3-8e3020b31c2a",
+                                    "name": "indexpattern-datasource-layer-bc4e65cf-0329-4ef1-ab2c-9b65e1d51af2",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "allowMultipleMetrics": true,
+                                        "categoryDisplay": "default",
+                                        "collapseFns": {
+                                            "612663d3-a04c-454f-8463-6a902020d937": "sum"
+                                        },
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorsByDimension": {
+                                            "0c220bec-d606-4d63-a9a3-76ad54d82579": "#d6bf57",
+                                            "7f02e9ad-00e6-4b08-bd65-d52691a1f69e": "#e7664c"
+                                        },
+                                        "emptySizeRatio": 0.3,
+                                        "layerId": "bc4e65cf-0329-4ef1-ab2c-9b65e1d51af2",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "metrics": [
+                                            "f71aa1e3-660e-42ff-93df-4d0c07361cad",
+                                            "50044e05-4069-4b17-9eeb-1f660804f30c",
+                                            "0c220bec-d606-4d63-a9a3-76ad54d82579",
+                                            "7f02e9ad-00e6-4b08-bd65-d52691a1f69e"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "value",
+                                        "primaryGroups": [
+                                            "612663d3-a04c-454f-8463-6a902020d937"
+                                        ]
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.phase",
+                                "index": "8d049466-cdf2-4c5b-97e3-8e3020b31c2a",
+                                "key": "metrics.k8s.pod.phase",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.phase"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Pods"
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "d3ad2e83-d078-4de8-ab2d-1b55ead3c162",
+                    "w": 8,
+                    "x": 11,
+                    "y": 20
+                },
+                "panelIndex": "d3ad2e83-d078-4de8-ab2d-1b55ead3c162",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "814876a7-ed03-4a55-b207-1b306043e2fd": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                    "name": "deployment-status-ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "deployment-not-ready": {
+                                            "script": {
+                                                "source": "if(doc.containsKey('metrics.k8s.deployment.available')){if (doc['metrics.k8s.deployment.available'].value != doc['metrics.k8s.deployment.desired'].value ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "deployment-ready": {
+                                            "script": {
+                                                "source": "if(doc.containsKey('metrics.k8s.deployment.available')){if (doc['metrics.k8s.deployment.available'].value == doc['metrics.k8s.deployment.desired'].value ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*otel*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "7060e036-5f61-44f7-b245-8541e83f5697": {
+                                            "columnOrder": [
+                                                "ae24bc8e-dda1-40de-863f-78050817c016",
+                                                "77cf4851-2ae1-4ed4-b952-ddd06bb78484",
+                                                "1f50b21b-2617-4e16-b406-ae96bb793345"
+                                            ],
+                                            "columns": {
+                                                "1f50b21b-2617-4e16-b406-ae96bb793345": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"deployment-not-ready\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Not Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "deployment-not-ready"
+                                                },
+                                                "77cf4851-2ae1-4ed4-b952-ddd06bb78484": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"deployment-ready\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "deployment-ready"
+                                                },
+                                                "ae24bc8e-dda1-40de-863f-78050817c016": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of resource.attributes.k8s.deployment.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "77cf4851-2ae1-4ed4-b952-ddd06bb78484",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.deployment.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                        "negate": false,
+                                        "params": [
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.deployment.available",
+                                                    "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                                    "key": "metrics.k8s.deployment.available",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.deployment.available"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.deployment.desired",
+                                                    "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                                    "key": "metrics.k8s.deployment.desired",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.deployment.desired"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "relation": "AND",
+                                        "type": "combined"
+                                    },
+                                    "query": {}
+                                }
+                            ],
+                            "internalReferences": [
+                                {
+                                    "id": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                    "name": "indexpattern-datasource-layer-7060e036-5f61-44f7-b245-8541e83f5697",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "allowMultipleMetrics": true,
+                                        "categoryDisplay": "default",
+                                        "collapseFns": {
+                                            "ae24bc8e-dda1-40de-863f-78050817c016": "sum"
+                                        },
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorsByDimension": {
+                                            "1f50b21b-2617-4e16-b406-ae96bb793345": "#e7664c"
+                                        },
+                                        "layerId": "7060e036-5f61-44f7-b245-8541e83f5697",
+                                        "layerType": "data",
+                                        "legendDisplay": "hide",
+                                        "metrics": [
+                                            "77cf4851-2ae1-4ed4-b952-ddd06bb78484",
+                                            "1f50b21b-2617-4e16-b406-ae96bb793345"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "value",
+                                        "primaryGroups": [
+                                            "ae24bc8e-dda1-40de-863f-78050817c016"
+                                        ]
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                "negate": false,
+                                "params": [
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.deployment.available",
+                                            "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                            "key": "metrics.k8s.deployment.available",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.deployment.available"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.deployment.desired",
+                                            "index": "814876a7-ed03-4a55-b207-1b306043e2fd",
+                                            "key": "metrics.k8s.deployment.desired",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.deployment.desired"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "relation": "AND",
+                                "type": "combined"
+                            },
+                            "query": {}
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Deployments"
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "0fd02500-5bf8-48a1-a353-980dabaa63a0",
+                    "w": 7,
+                    "x": 19,
+                    "y": 20
+                },
+                "panelIndex": "0fd02500-5bf8-48a1-a353-980dabaa63a0",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "bd8dfa94-665d-4be3-ba79-bf8b01440d0a": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                    "name": "daemonset-status-ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "daemonset-not-ready": {
+                                            "script": {
+                                                "source": "if(doc.containsKey('metrics.k8s.daemonset.ready_nodes')){if (doc['metrics.k8s.daemonset.ready_nodes'].value != doc['metrics.k8s.daemonset.desired_scheduled_nodes'].value ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "daemonset-ready": {
+                                            "script": {
+                                                "source": "if(doc.containsKey('metrics.k8s.daemonset.ready_nodes')){if (doc['metrics.k8s.daemonset.ready_nodes'].value == doc['metrics.k8s.daemonset.desired_scheduled_nodes'].value ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*otel*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "44315f34-5db4-4895-9515-c0d25fc881d3": {
+                                            "columnOrder": [
+                                                "10b38a83-9639-43bf-ad8f-294349b21c87",
+                                                "1b85330f-66e6-4c2f-bb06-f16e50bc63d4",
+                                                "72e39169-95bd-426b-b7ba-1ddd1c351d6e"
+                                            ],
+                                            "columns": {
+                                                "10b38a83-9639-43bf-ad8f-294349b21c87": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of resource.attributes.k8s.daemonset.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "1b85330f-66e6-4c2f-bb06-f16e50bc63d4",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.daemonset.name"
+                                                },
+                                                "1b85330f-66e6-4c2f-bb06-f16e50bc63d4": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"daemonset-ready\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "daemonset-ready"
+                                                },
+                                                "72e39169-95bd-426b-b7ba-1ddd1c351d6e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"daemonset-not-ready\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Not Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "daemonset-not-ready"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                        "negate": false,
+                                        "params": [
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.daemonset.ready_nodes",
+                                                    "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                                    "key": "metrics.k8s.daemonset.ready_nodes",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.daemonset.ready_nodes"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.daemonset.desired_scheduled_nodes",
+                                                    "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                                    "key": "metrics.k8s.daemonset.desired_scheduled_nodes",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.daemonset.desired_scheduled_nodes"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "relation": "AND",
+                                        "type": "combined"
+                                    },
+                                    "query": {}
+                                }
+                            ],
+                            "internalReferences": [
+                                {
+                                    "id": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                    "name": "indexpattern-datasource-layer-44315f34-5db4-4895-9515-c0d25fc881d3",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "allowMultipleMetrics": true,
+                                        "categoryDisplay": "default",
+                                        "collapseFns": {
+                                            "10b38a83-9639-43bf-ad8f-294349b21c87": "sum"
+                                        },
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorsByDimension": {
+                                            "72e39169-95bd-426b-b7ba-1ddd1c351d6e": "#e7664c"
+                                        },
+                                        "layerId": "44315f34-5db4-4895-9515-c0d25fc881d3",
+                                        "layerType": "data",
+                                        "legendDisplay": "hide",
+                                        "metrics": [
+                                            "1b85330f-66e6-4c2f-bb06-f16e50bc63d4",
+                                            "72e39169-95bd-426b-b7ba-1ddd1c351d6e"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "value",
+                                        "primaryGroups": [
+                                            "10b38a83-9639-43bf-ad8f-294349b21c87"
+                                        ]
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                "negate": false,
+                                "params": [
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.daemonset.ready_nodes",
+                                            "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                            "key": "metrics.k8s.daemonset.ready_nodes",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.daemonset.ready_nodes"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.daemonset.desired_scheduled_nodes",
+                                            "index": "bd8dfa94-665d-4be3-ba79-bf8b01440d0a",
+                                            "key": "metrics.k8s.daemonset.desired_scheduled_nodes",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.daemonset.desired_scheduled_nodes"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "relation": "AND",
+                                "type": "combined"
+                            },
+                            "query": {}
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "DaemonSets"
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "d3ef0cb4-5127-47cf-a7c5-5ac86cd8f893",
+                    "w": 7,
+                    "x": 26,
+                    "y": 20
+                },
+                "panelIndex": "d3ef0cb4-5127-47cf-a7c5-5ac86cd8f893",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "f69ab194-236a-4e59-9dc0-b5a1bac9e841": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                    "name": "statefulset-status-ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "statefulset-not-ready": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('metrics.k8s.statefulset.ready_pods')){if (doc['metrics.k8s.statefulset.ready_pods'].value != doc['metrics.k8s.statefulset.desired_pods'].value ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "statefulset-ready": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('metrics.k8s.statefulset.ready_pods')){if (doc['metrics.k8s.statefulset.ready_pods'].value == doc['metrics.k8s.statefulset.desired_pods'].value ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*otel*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "f7dee37f-6dc8-40ab-81ce-36f0d67ce506": {
+                                            "columnOrder": [
+                                                "f26bbdb6-0edc-46bb-8fbc-816c6dfc5e1a",
+                                                "c6848965-c8b5-4aa6-bfa2-9d89181ebb21",
+                                                "fb95236b-d21a-482b-acd1-bf212441b013"
+                                            ],
+                                            "columns": {
+                                                "c6848965-c8b5-4aa6-bfa2-9d89181ebb21": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"statefulset-ready\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "statefulset-ready"
+                                                },
+                                                "f26bbdb6-0edc-46bb-8fbc-816c6dfc5e1a": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of resource.attributes.k8s.statefulset.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "c6848965-c8b5-4aa6-bfa2-9d89181ebb21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.statefulset.name"
+                                                },
+                                                "fb95236b-d21a-482b-acd1-bf212441b013": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"statefulset-not-ready\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Not Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "statefulset-not-ready"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                        "negate": false,
+                                        "params": [
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.statefulset.ready_pods",
+                                                    "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                                    "key": "metrics.k8s.statefulset.ready_pods",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.statefulset.ready_pods"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.statefulset.desired_pods",
+                                                    "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                                    "key": "metrics.k8s.statefulset.desired_pods",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.statefulset.desired_pods"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "relation": "AND",
+                                        "type": "combined"
+                                    },
+                                    "query": {}
+                                }
+                            ],
+                            "internalReferences": [
+                                {
+                                    "id": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                    "name": "indexpattern-datasource-layer-f7dee37f-6dc8-40ab-81ce-36f0d67ce506",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "allowMultipleMetrics": true,
+                                        "categoryDisplay": "default",
+                                        "collapseFns": {
+                                            "f26bbdb6-0edc-46bb-8fbc-816c6dfc5e1a": "sum"
+                                        },
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorsByDimension": {
+                                            "fb95236b-d21a-482b-acd1-bf212441b013": "#e7664c"
+                                        },
+                                        "layerId": "f7dee37f-6dc8-40ab-81ce-36f0d67ce506",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "metrics": [
+                                            "c6848965-c8b5-4aa6-bfa2-9d89181ebb21",
+                                            "fb95236b-d21a-482b-acd1-bf212441b013"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "value",
+                                        "primaryGroups": [
+                                            "f26bbdb6-0edc-46bb-8fbc-816c6dfc5e1a"
+                                        ]
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                "negate": false,
+                                "params": [
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.statefulset.ready_pods",
+                                            "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                            "key": "metrics.k8s.statefulset.ready_pods",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.statefulset.ready_pods"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.statefulset.desired_pods",
+                                            "index": "f69ab194-236a-4e59-9dc0-b5a1bac9e841",
+                                            "key": "metrics.k8s.statefulset.desired_pods",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.statefulset.desired_pods"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "relation": "AND",
+                                "type": "combined"
+                            },
+                            "query": {}
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "StatefulSets"
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "07750821-29c6-482f-86fe-4e166220e988",
+                    "w": 7,
+                    "x": 33,
+                    "y": 20
+                },
+                "panelIndex": "07750821-29c6-482f-86fe-4e166220e988",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "b79aec1e-320f-4bce-89bb-abb64f61d0cf": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                    "name": "replicaset-status-ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "replicaset-not-ready": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('metrics.k8s.replicaset.available')){ if (doc['metrics.k8s.replicaset.available'].value != doc['metrics.k8s.replicaset.desired'].value ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "replicaset-ready": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('metrics.k8s.replicaset.available')){ if (doc['metrics.k8s.replicaset.available'].value == doc['metrics.k8s.replicaset.desired'].value ) { emit(1) }}"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*otel*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "904620a1-1feb-489f-abcd-45ea924e1955": {
+                                            "columnOrder": [
+                                                "11cdcee4-b164-425e-a82f-8a9e7cdc070a",
+                                                "19c8faad-d1f0-4a6c-ae49-6677ece85012",
+                                                "a8740ebb-1aa5-45fd-9800-3107688828f3"
+                                            ],
+                                            "columns": {
+                                                "11cdcee4-b164-425e-a82f-8a9e7cdc070a": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of resource.attributes.k8s.replicaset.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "19c8faad-d1f0-4a6c-ae49-6677ece85012",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.replicaset.name"
+                                                },
+                                                "19c8faad-d1f0-4a6c-ae49-6677ece85012": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"replicaset-ready\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "replicaset-ready"
+                                                },
+                                                "a8740ebb-1aa5-45fd-9800-3107688828f3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"replicaset-not-ready\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Not Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "replicaset-not-ready"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                        "negate": false,
+                                        "params": [
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.replicaset.available",
+                                                    "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                                    "key": "metrics.k8s.replicaset.available",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.replicaset.available"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "meta": {
+                                                    "disabled": false,
+                                                    "field": "metrics.k8s.replicaset.desired",
+                                                    "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                                    "key": "metrics.k8s.replicaset.desired",
+                                                    "negate": false,
+                                                    "type": "exists",
+                                                    "value": "exists"
+                                                },
+                                                "query": {
+                                                    "exists": {
+                                                        "field": "metrics.k8s.replicaset.desired"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "relation": "AND",
+                                        "type": "combined"
+                                    },
+                                    "query": {}
+                                }
+                            ],
+                            "internalReferences": [
+                                {
+                                    "id": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                    "name": "indexpattern-datasource-layer-904620a1-1feb-489f-abcd-45ea924e1955",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "allowMultipleMetrics": true,
+                                        "categoryDisplay": "default",
+                                        "collapseFns": {
+                                            "11cdcee4-b164-425e-a82f-8a9e7cdc070a": "sum"
+                                        },
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorsByDimension": {
+                                            "a8740ebb-1aa5-45fd-9800-3107688828f3": "#e7664c"
+                                        },
+                                        "layerId": "904620a1-1feb-489f-abcd-45ea924e1955",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "metrics": [
+                                            "19c8faad-d1f0-4a6c-ae49-6677ece85012",
+                                            "a8740ebb-1aa5-45fd-9800-3107688828f3"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "value",
+                                        "primaryGroups": [
+                                            "11cdcee4-b164-425e-a82f-8a9e7cdc070a"
+                                        ]
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                "negate": false,
+                                "params": [
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.replicaset.available",
+                                            "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                            "key": "metrics.k8s.replicaset.available",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.replicaset.available"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "meta": {
+                                            "disabled": false,
+                                            "field": "metrics.k8s.replicaset.desired",
+                                            "index": "b79aec1e-320f-4bce-89bb-abb64f61d0cf",
+                                            "key": "metrics.k8s.replicaset.desired",
+                                            "negate": false,
+                                            "type": "exists",
+                                            "value": "exists"
+                                        },
+                                        "query": {
+                                            "exists": {
+                                                "field": "metrics.k8s.replicaset.desired"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "relation": "AND",
+                                "type": "combined"
+                            },
+                            "query": {}
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "ReplicaSets"
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "8645e647-e6ed-497d-ab2b-f6003ea6a002",
+                    "w": 8,
+                    "x": 40,
+                    "y": 20
+                },
+                "panelIndex": "8645e647-e6ed-497d-ab2b-f6003ea6a002",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "as Pct of the Node allocatable",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "5cd693aa-6e5b-43de-b3c5-3d353a0644a3": {
+                                            "columnOrder": [
+                                                "21116a07-c482-413a-9a0e-8e0f8c556810",
+                                                "ebefe510-97b1-4f35-b8c7-9ee4d964d695"
+                                            ],
+                                            "columns": {
+                                                "21116a07-c482-413a-9a0e-8e0f8c556810": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of resource.attributes.k8s.pod.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "accuracyMode": false,
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "ebefe510-97b1-4f35-b8c7-9ee4d964d695",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.pod.name"
+                                                },
+                                                "ebefe510-97b1-4f35-b8c7-9ee4d964d695": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.pod.cpu.node.utilization\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Pod CPU Utilization ",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        },
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.pod.cpu.node.utilization"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "metrics.k8s.pod.cpu.node.utilization",
+                                        "index": "c8a8f71b-f32b-46ab-aca4-e4eda5ee48f6",
+                                        "key": "metrics.k8s.pod.cpu.node.utilization",
+                                        "negate": false,
+                                        "type": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "metrics.k8s.pod.cpu.node.utilization"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "ebefe510-97b1-4f35-b8c7-9ee4d964d695"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "xAccessor": "21116a07-c482-413a-9a0e-8e0f8c556810",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "auto",
+                                                "forAccessor": "ebefe510-97b1-4f35-b8c7-9ee4d964d695"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "show",
+                                "xTitle": "% CPU Node",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Pod cpu utilization is calculated as a ratio of the total node's capacity",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.cpu.node.utilization",
+                                "index": "c8a8f71b-f32b-46ab-aca4-e4eda5ee48f6",
+                                "key": "metrics.k8s.pod.cpu.node.utilization",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.cpu.node.utilization"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Top CPU intensive pods per Node"
+                },
+                "gridData": {
+                    "h": 10,
+                    "i": "511eabaf-6c53-4b16-8574-4a259e5f0cb7",
+                    "w": 11,
+                    "x": 0,
+                    "y": 26
+                },
+                "panelIndex": "511eabaf-6c53-4b16-8574-4a259e5f0cb7",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "as Pct of the Pod Limit",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "5cd693aa-6e5b-43de-b3c5-3d353a0644a3": {
+                                            "columnOrder": [
+                                                "21116a07-c482-413a-9a0e-8e0f8c556810",
+                                                "ebefe510-97b1-4f35-b8c7-9ee4d964d695"
+                                            ],
+                                            "columns": {
+                                                "21116a07-c482-413a-9a0e-8e0f8c556810": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of resource.attributes.k8s.pod.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "accuracyMode": true,
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "ebefe510-97b1-4f35-b8c7-9ee4d964d695",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.pod.name"
+                                                },
+                                                "ebefe510-97b1-4f35-b8c7-9ee4d964d695": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.pod.cpu_limit_utilization\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Pod CPU Utilization ",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        },
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.pod.cpu_limit_utilization"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "metrics.k8s.pod.cpu_limit_utilization",
+                                        "index": "6f57f91d-975d-48f3-9857-81fd9c2299a5",
+                                        "key": "metrics.k8s.pod.cpu_limit_utilization",
+                                        "negate": false,
+                                        "type": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "metrics.k8s.pod.cpu_limit_utilization"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "ebefe510-97b1-4f35-b8c7-9ee4d964d695"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "xAccessor": "21116a07-c482-413a-9a0e-8e0f8c556810",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "auto",
+                                                "forAccessor": "ebefe510-97b1-4f35-b8c7-9ee4d964d695"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "show",
+                                "xTitle": "% CPU Pod limit"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Pod cpu utilization is calculated as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted.",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.cpu_limit_utilization",
+                                "index": "6f57f91d-975d-48f3-9857-81fd9c2299a5",
+                                "key": "metrics.k8s.pod.cpu_limit_utilization",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.cpu_limit_utilization"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Top CPU intensive pods per Pod Limit"
+                },
+                "gridData": {
+                    "h": 10,
+                    "i": "a713782d-4265-4e4c-bb27-a898445e25a0",
+                    "w": 12,
+                    "x": 11,
+                    "y": 26
+                },
+                "panelIndex": "a713782d-4265-4e4c-bb27-a898445e25a0",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "as Pct of the Node allocatable",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "5cd693aa-6e5b-43de-b3c5-3d353a0644a3": {
+                                            "columnOrder": [
+                                                "21116a07-c482-413a-9a0e-8e0f8c556810",
+                                                "ebefe510-97b1-4f35-b8c7-9ee4d964d695"
+                                            ],
+                                            "columns": {
+                                                "21116a07-c482-413a-9a0e-8e0f8c556810": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of resource.attributes.k8s.pod.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "accuracyMode": true,
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "ebefe510-97b1-4f35-b8c7-9ee4d964d695",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.pod.name"
+                                                },
+                                                "ebefe510-97b1-4f35-b8c7-9ee4d964d695": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"metrics.k8s.pod.memory.node.utilization\" :*"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Pod Memory Utilization",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        },
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.pod.memory.node.utilization"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "metrics.k8s.pod.memory.node.utilization",
+                                        "index": "9104052a-0152-4e6d-89c1-bb3c40c89576",
+                                        "key": "metrics.k8s.pod.memory.node.utilization",
+                                        "negate": false,
+                                        "type": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "metrics.k8s.pod.memory.node.utilization"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "ebefe510-97b1-4f35-b8c7-9ee4d964d695"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "xAccessor": "21116a07-c482-413a-9a0e-8e0f8c556810",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "auto",
+                                                "forAccessor": "ebefe510-97b1-4f35-b8c7-9ee4d964d695"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "show",
+                                "xTitle": "% Memory Node"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Pod memory utilization is calculated as a ratio of the total node's capacity",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.memory.node.utilization",
+                                "index": "9104052a-0152-4e6d-89c1-bb3c40c89576",
+                                "key": "metrics.k8s.pod.memory.node.utilization",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.memory.node.utilization"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Top Memory intensive pods per Node"
+                },
+                "gridData": {
+                    "h": 10,
+                    "i": "0e75873c-7ec7-423c-8772-8529314f30ea",
+                    "w": 13,
+                    "x": 23,
+                    "y": 26
+                },
+                "panelIndex": "0e75873c-7ec7-423c-8772-8529314f30ea",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "(as Pct of the Pod Limit)",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "5cd693aa-6e5b-43de-b3c5-3d353a0644a3": {
+                                            "columnOrder": [
+                                                "21116a07-c482-413a-9a0e-8e0f8c556810",
+                                                "b78e2935-5913-4117-908a-e051de699eb9"
+                                            ],
+                                            "columns": {
+                                                "21116a07-c482-413a-9a0e-8e0f8c556810": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of resource.attributes.k8s.pod.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "accuracyMode": false,
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "b78e2935-5913-4117-908a-e051de699eb9",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "resource.attributes.k8s.pod.name"
+                                                },
+                                                "b78e2935-5913-4117-908a-e051de699eb9": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "metrics.k8s.pod.memory_limit_utilization :*"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Pod Memory Utilization",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "metrics.k8s.pod.memory_limit_utilization"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "metrics.k8s.pod.memory_limit_utilization",
+                                        "index": "7dd9ddda-fbe9-4bed-8865-aee8e880ce2d",
+                                        "key": "metrics.k8s.pod.memory_limit_utilization",
+                                        "negate": false,
+                                        "type": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "metrics.k8s.pod.memory_limit_utilization"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset: *.otel"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "b78e2935-5913-4117-908a-e051de699eb9"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "xAccessor": "21116a07-c482-413a-9a0e-8e0f8c556810",
+                                        "yConfig": []
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "show",
+                                "xTitle": "% Memory Pod Limit",
+                                "yLeftExtent": {
+                                    "mode": "full",
+                                    "niceValues": true
+                                }
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Pod memory utilization is calculated as a ratio of the pod's total container memory limits. If any container is missing a limit the metric is not emitted.",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "metrics.k8s.pod.memory_limit_utilization",
+                                "index": "7dd9ddda-fbe9-4bed-8865-aee8e880ce2d",
+                                "key": "metrics.k8s.pod.memory_limit_utilization",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "metrics.k8s.pod.memory_limit_utilization"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": "data_stream.dataset: *.otel"
+                    },
+                    "searchSessionId": "e9f504a9-e932-4972-91c1-d05289ae2b5d",
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Top Memory intensive pods per Pod Limit"
+                },
+                "gridData": {
+                    "h": 10,
+                    "i": "198355ac-42b6-4e7a-83f3-32780c160b3f",
+                    "w": 12,
+                    "x": 36,
+                    "y": 26
+                },
+                "panelIndex": "198355ac-42b6-4e7a-83f3-32780c160b3f",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "hidePanelTitles": true,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "#### Cluster Events",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "aab122d7-aa5f-4d82-be3e-bd666830f1fd",
+                    "w": 48,
+                    "x": 0,
+                    "y": 36
+                },
+                "panelIndex": "aab122d7-aa5f-4d82-be3e-bd666830f1fd",
+                "type": "visualization"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-29bf96fd-6dcd-4667-8e14-8865fb5a7e63",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "8845036c-ee4f-4c36-b022-d1809e9e900d",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "6a3ed146-aa6a-4cba-b445-d3aba5a3f146",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {
+                                "12cd51e3-7dfe-48bc-a6fb-b864bc993b27": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "12cd51e3-7dfe-48bc-a6fb-b864bc993b27",
+                                    "name": "events",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "logs-generic.otel-default"
+                                },
+                                "f641ba62-c9ca-4f45-ba95-3d68c419a5a5": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "f641ba62-c9ca-4f45-ba95-3d68c419a5a5",
+                                    "name": "events-ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "resource.attributes.k8s.namespace.name": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('body_structured.object.regarding.kind')) {\n    if (doc['body_structured.object.regarding.kind'].value == \"Pod\") {\n        emit(doc['body_structured.object.regarding.namespace'].value);\n    }\n}"
+                                            },
+                                            "type": "keyword"
+                                        },
+                                        "resource.attributes.k8s.node.name": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('body_structured.object.regarding.kind')) {\n    if (doc['body_structured.object.regarding.kind'].value == \"Node\") {\n        emit(doc['body_structured.object.regarding.name'].value);\n    }\n    if (doc['body_structured.object.regarding.kind'].value == \"Pod\") {\n        emit(doc['body_structured.object.reportingInstance'].value);\n    }\n}"
+                                            },
+                                            "type": "keyword"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "logs-*otel*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "29bf96fd-6dcd-4667-8e14-8865fb5a7e63": {
+                                            "columnOrder": [
+                                                "2988be4a-0304-42eb-85bd-d805ab4bd297",
+                                                "5f4d7cd7-5853-47c5-9fd3-bcc5a0ad5da8",
+                                                "575ac688-e369-4249-8790-712a76ed4184"
+                                            ],
+                                            "columns": {
+                                                "2988be4a-0304-42eb-85bd-d805ab4bd297": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of body.structured.object.regarding.kind + 1 other",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "575ac688-e369-4249-8790-712a76ed4184",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "body.structured.object.reason"
+                                                        ],
+                                                        "size": 1000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "body.structured.object.regarding.kind"
+                                                },
+                                                "575ac688-e369-4249-8790-712a76ed4184": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of body.structured.object.kind",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "body.structured.object.kind"
+                                                },
+                                                "5f4d7cd7-5853-47c5-9fd3-bcc5a0ad5da8": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "body.structured.object.kind",
+                                        "index": "8845036c-ee4f-4c36-b022-d1809e9e900d",
+                                        "key": "body.structured.object.kind",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "Event"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "body.structured.object.kind": "Event"
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "body.structured.object.type",
+                                        "index": "6a3ed146-aa6a-4cba-b445-d3aba5a3f146",
+                                        "key": "body.structured.object.type",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "Normal"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "body.structured.object.type": "Normal"
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "f641ba62-c9ca-4f45-ba95-3d68c419a5a5",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "kubernetes.event.otel"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "kubernetes.event.otel"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "hideEndzones": false,
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "575ac688-e369-4249-8790-712a76ed4184"
+                                        ],
+                                        "layerId": "29bf96fd-6dcd-4667-8e14-8865fb5a7e63",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "bar_stacked",
+                                        "splitAccessor": "2988be4a-0304-42eb-85bd-d805ab4bd297",
+                                        "xAccessor": "5f4d7cd7-5853-47c5-9fd3-bcc5a0ad5da8"
+                                    }
+                                ],
+                                "legend": {
+                                    "floatingColumns": 1,
+                                    "horizontalAlignment": "right",
+                                    "isInside": true,
+                                    "isVisible": true,
+                                    "position": "right",
+                                    "showSingleSeries": false,
+                                    "verticalAlignment": "top"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "valueLabels": "show"
+                            }
+                        },
+                        "title": "Kubernetes Warning and Error Events",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "body.structured.object.kind",
+                                "index": "8845036c-ee4f-4c36-b022-d1809e9e900d",
+                                "key": "body.structured.object.kind",
+                                "negate": false,
+                                "params": {
+                                    "query": "Event"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "body.structured.object.kind": "Event"
+                                }
+                            }
+                        },
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "body.structured.object.type",
+                                "index": "6a3ed146-aa6a-4cba-b445-d3aba5a3f146",
+                                "key": "body.structured.object.type",
+                                "negate": true,
+                                "params": {
+                                    "query": "Normal"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "body.structured.object.type": "Normal"
+                                }
+                            }
+                        },
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "data_stream.dataset",
+                                "index": "f641ba62-c9ca-4f45-ba95-3d68c419a5a5",
+                                "key": "data_stream.dataset",
+                                "negate": false,
+                                "params": {
+                                    "query": "kubernetes.event.otel"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "data_stream.dataset": "kubernetes.event.otel"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": ""
+                    },
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Occurrences of Warning  Events"
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "cebebdbb-dc0b-4c9c-a002-35d6f4bc1495",
+                    "w": 23,
+                    "x": 0,
+                    "y": 40
+                },
+                "panelIndex": "cebebdbb-dc0b-4c9c-a002-35d6f4bc1495",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-4581d01c-5f91-4098-bb19-36de6b81d665",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {
+                                "3769faab-05d7-4801-a802-b96342983e85": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "3769faab-05d7-4801-a802-b96342983e85",
+                                    "name": "events-ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "resource.attributes.k8s.namespace.name": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('body_structured.object.regarding.kind')) {\n    if (doc['body_structured.object.regarding.kind'].value == \"Pod\") {\n        emit(doc['body_structured.object.regarding.namespace'].value);\n    }\n}"
+                                            },
+                                            "type": "keyword"
+                                        },
+                                        "resource.attributes.k8s.node.name": {
+                                            "script": {
+                                                "source": "if (doc.containsKey('body_structured.object.regarding.kind')) {\n    if (doc['body_structured.object.regarding.kind'].value == \"Node\") {\n        emit(doc['body_structured.object.regarding.name'].value);\n    }\n    if (doc['body_structured.object.regarding.kind'].value == \"Pod\") {\n        emit(doc['body_structured.object.reportingInstance'].value);\n    }\n}"
+                                            },
+                                            "type": "keyword"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "logs-*otel*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "4581d01c-5f91-4098-bb19-36de6b81d665": {
+                                            "columnOrder": [
+                                                "cba8fb16-cb3d-4a75-ad6b-d4d8912ca613",
+                                                "f7b00ef7-ed81-40ab-9fc3-c868c2d86196",
+                                                "12e85c3f-8efa-4ecb-bbae-3889218d736b",
+                                                "b7306eee-3b79-4b81-8ba6-e6aca02e90fd",
+                                                "cde7d210-0d76-4a32-92b6-bdfce76aaa1b",
+                                                "8bc50583-b210-4176-8ac2-326cf516d422",
+                                                "56feaaf4-3059-4b1d-b738-93077b673ff3"
+                                            ],
+                                            "columns": {
+                                                "12e85c3f-8efa-4ecb-bbae-3889218d736b": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "56feaaf4-3059-4b1d-b738-93077b673ff3",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 100
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "body.structured.object.regarding.name"
+                                                },
+                                                "56feaaf4-3059-4b1d-b738-93077b673ff3": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of body.structured.object.kind",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "body.structured.object.kind"
+                                                },
+                                                "8bc50583-b210-4176-8ac2-326cf516d422": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Reason",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "56feaaf4-3059-4b1d-b738-93077b673ff3",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 100
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "body.structured.object.reason"
+                                                },
+                                                "b7306eee-3b79-4b81-8ba6-e6aca02e90fd": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Namespace",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "56feaaf4-3059-4b1d-b738-93077b673ff3",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 100
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "body.structured.object.metadata.namespace"
+                                                },
+                                                "cba8fb16-cb3d-4a75-ad6b-d4d8912ca613": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Creation Timestamp",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "56feaaf4-3059-4b1d-b738-93077b673ff3",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 100
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "body.structured.object.metadata.creationTimestamp"
+                                                },
+                                                "cde7d210-0d76-4a32-92b6-bdfce76aaa1b": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Message",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "56feaaf4-3059-4b1d-b738-93077b673ff3",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 100
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "body.structured.object.note"
+                                                },
+                                                "f7b00ef7-ed81-40ab-9fc3-c868c2d86196": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Resource",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "56feaaf4-3059-4b1d-b738-93077b673ff3",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 100
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "body.structured.object.regarding.kind"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "3769faab-05d7-4801-a802-b96342983e85",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "kubernetes.event.otel"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "kubernetes.event.otel"
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "body.structured.object.kind",
+                                        "index": "d5ed4c9b-9c6f-49f0-833b-1830cb637329",
+                                        "key": "body.structured.object.kind",
+                                        "negate": false,
+                                        "type": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "body.structured.object.kind"
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "body.structured.object.type",
+                                        "index": "432b9a4d-65d2-44b1-ba84-473ae598be20",
+                                        "key": "body.structured.object.type",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "Normal"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "body.structured.object.type": "Normal"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "cba8fb16-cb3d-4a75-ad6b-d4d8912ca613",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "12e85c3f-8efa-4ecb-bbae-3889218d736b",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "b7306eee-3b79-4b81-8ba6-e6aca02e90fd",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "cde7d210-0d76-4a32-92b6-bdfce76aaa1b",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "f7b00ef7-ed81-40ab-9fc3-c868c2d86196",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "56feaaf4-3059-4b1d-b738-93077b673ff3",
+                                        "hidden": true,
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "8bc50583-b210-4176-8ac2-326cf516d422",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "headerRowHeight": "single",
+                                "headerRowHeightLines": 1,
+                                "layerId": "4581d01c-5f91-4098-bb19-36de6b81d665",
+                                "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
+                                "rowHeight": "auto"
+                            }
+                        },
+                        "title": "Latest Warning Events",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "description": "",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "data_stream.dataset",
+                                "index": "3769faab-05d7-4801-a802-b96342983e85",
+                                "key": "data_stream.dataset",
+                                "negate": false,
+                                "params": {
+                                    "query": "kubernetes.event.otel"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "data_stream.dataset": "kubernetes.event.otel"
+                                }
+                            }
+                        },
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "body.structured.object.kind",
+                                "index": "d5ed4c9b-9c6f-49f0-833b-1830cb637329",
+                                "key": "body.structured.object.kind",
+                                "negate": false,
+                                "type": "exists"
+                            },
+                            "query": {
+                                "exists": {
+                                    "field": "body.structured.object.kind"
+                                }
+                            }
+                        },
+                        {
+                            "$state": {
+                                "store": "appState"
+                            },
+                            "meta": {
+                                "alias": null,
+                                "disabled": false,
+                                "field": "body.structured.object.type",
+                                "index": "432b9a4d-65d2-44b1-ba84-473ae598be20",
+                                "key": "body.structured.object.type",
+                                "negate": true,
+                                "params": {
+                                    "query": "Normal"
+                                },
+                                "type": "phrase"
+                            },
+                            "query": {
+                                "match_phrase": {
+                                    "body.structured.object.type": "Normal"
+                                }
+                            }
+                        }
+                    ],
+                    "query": {
+                        "language": "kuery",
+                        "query": ""
+                    },
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Latest Warning Events"
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "ceab1891-f90d-44c4-8d49-ec9cbc33680d",
+                    "w": 25,
+                    "x": 23,
+                    "y": 40
+                },
+                "panelIndex": "ceab1891-f90d-44c4-8d49-ec9cbc33680d",
+                "type": "lens"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[PPBGDI][OTEL][Metrics Kubernetes] Cluster Overview",
+        "version": 3
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2025-08-26T16:07:33.751Z",
+    "created_by": "u_sP08ryP_8DaI2BOI1OrgtHHVlKzdufxxIV92_MPnv8o_0",
+    "id": "ppbgdi-cfe0d27f-b390-4585-8910-78953e0bd447",
+    "references": [
+        {
+            "id": "ppbgdi-fleet-pkg-kubernetes_otel-default",
+            "name": "tag-ref-fleet-pkg-kubernetes_otel-default",
+            "type": "tag"
+        },
+        {
+            "id": "ppbgdi-fleet-shared-tag-kubernetes_otel-dfd505f6-fc02-5c53-adc7-148425d7972c-default",
+            "name": "tag-ref-fleet-shared-tag-kubernetes_otel-dfd505f6-fc02-5c53-adc7-148425d7972c-default",
+            "type": "tag"
+        },
+        {
+            "id": "metrics-*",
+            "name": "62b7952e-3465-4519-9d4a-eb8c90cbb09d:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "39dd2546-a07a-49e5-a432-5e1b64b6cb13:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "39dd2546-a07a-49e5-a432-5e1b64b6cb13:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "f338dd4f-f6a0-4ef3-a9cb-2ec7a3894415:indexpattern-datasource-layer-54494aa2-197e-42d6-a8ef-0072655ca351",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "f338dd4f-f6a0-4ef3-a9cb-2ec7a3894415:indexpattern-datasource-layer-dba09ccc-6ec6-443b-8620-1eac10077772",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "95e20a83-c9b8-4046-a479-605870bf7a21:indexpattern-datasource-layer-894781bd-2933-418c-b883-1f758794a45d",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "ce370870-81e2-4649-acc2-fddcae3686dc:indexpattern-datasource-layer-b5e4cee3-e558-4805-b276-673a7ebff8f0",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "b618f38b-8aa4-459a-89dc-eab8b4f6d1a7:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "1f8d34d9-bad8-41fc-8812-087281430b3a:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a45c94ad-f7e4-47f6-9da8-f77a2e0540b4:indexpattern-datasource-layer-f494e875-7646-4748-b9d8-e4120c00e866",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a45c94ad-f7e4-47f6-9da8-f77a2e0540b4:1b04b540-39ae-4cfd-8088-34a4bf3d5654",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "15285038-9ec2-4e24-858c-6713dba71e32:indexpattern-datasource-layer-57a8eb42-6f2c-4112-9d6c-c03d982c569e",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "15285038-9ec2-4e24-858c-6713dba71e32:0e11ca27-40f5-4300-b885-17ade4895220",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "511eabaf-6c53-4b16-8574-4a259e5f0cb7:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a713782d-4265-4e4c-bb27-a898445e25a0:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "0e75873c-7ec7-423c-8772-8529314f30ea:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "198355ac-42b6-4e7a-83f3-32780c160b3f:indexpattern-datasource-layer-5cd693aa-6e5b-43de-b3c5-3d353a0644a3",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "cebebdbb-dc0b-4c9c-a002-35d6f4bc1495:indexpattern-datasource-layer-29bf96fd-6dcd-4667-8e14-8865fb5a7e63",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "cebebdbb-dc0b-4c9c-a002-35d6f4bc1495:8845036c-ee4f-4c36-b022-d1809e9e900d",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "cebebdbb-dc0b-4c9c-a002-35d6f4bc1495:6a3ed146-aa6a-4cba-b445-d3aba5a3f146",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "ceab1891-f90d-44c4-8d49-ec9cbc33680d:indexpattern-datasource-layer-4581d01c-5f91-4098-bb19-36de6b81d665",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_fc4570df-08ee-4629-85db-901b3008f61a:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_a040080e-8a63-4000-85fa-59cc2e48067d:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_d0079981-006d-4357-aed8-a05eef49b2eb:optionsListDataView",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "dashboard",
+    "typeMigrationVersion": "10.3.0",
+    "updated_by": "u_sP08ryP_8DaI2BOI1OrgtHHVlKzdufxxIV92_MPnv8o_0"
+}

--- a/packages/ppbgdi/kibana/tag/ppbgdi-fleet-pkg-kubernetes_otel-default.json
+++ b/packages/ppbgdi/kibana/tag/ppbgdi-fleet-pkg-kubernetes_otel-default.json
@@ -1,0 +1,13 @@
+{
+    "attributes": {
+        "color": "#4DD2CA",
+        "description": "",
+        "name": "Kubernetes OpenTelemetry Assets"
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2024-12-13T13:36:25.940Z",
+    "id": "ppbgdi-fleet-pkg-kubernetes_otel-default",
+    "references": [],
+    "type": "tag",
+    "typeMigrationVersion": "8.0.0"
+}

--- a/packages/ppbgdi/kibana/tag/ppbgdi-fleet-shared-tag-kubernetes_otel-dfd505f6-fc02-5c53-adc7-148425d7972c-default.json
+++ b/packages/ppbgdi/kibana/tag/ppbgdi-fleet-shared-tag-kubernetes_otel-dfd505f6-fc02-5c53-adc7-148425d7972c-default.json
@@ -1,0 +1,13 @@
+{
+    "attributes": {
+        "color": "#FFA500",
+        "description": "Tag defined in package-spec",
+        "name": "OpenTelemetry"
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2024-12-13T13:36:26.094Z",
+    "id": "ppbgdi-fleet-shared-tag-kubernetes_otel-dfd505f6-fc02-5c53-adc7-148425d7972c-default",
+    "references": [],
+    "type": "tag",
+    "typeMigrationVersion": "8.0.0"
+}

--- a/packages/ppbgdi/manifest.yml
+++ b/packages/ppbgdi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.1
 name: ppbgdi
 title: "PPBGDI"
-version: 1.6.2
+version: 1.7.0
 source:
   license: "Apache-2.0"
 description: "Collect logs and metrics from PPBGDI, via kubernetes or Elastic Agent"


### PR DESCRIPTION
Added (temporary) working dashboard until official dashboard is fixed.

The fix filters events on `data_stream.dataset` `kubernetes.event.otel` `instead of generic.otel.