### PR TITLE
PB-2095: fix CloudFront metrics dashboard id

### DIFF
--- a/packages/ppbgdi/changelog.yml
+++ b/packages/ppbgdi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.1"
+  changes:
+    - description: Fix CloudFront metrics dashboard id
+      type: bugfix
+      link: https://github.com/geoadmin/infra-elastic-integrations/pull/52
 - version: "2.1.0"
   changes:
     - description: Add CloudFront metrics dashboard

--- a/packages/ppbgdi/kibana/dashboard/ppbgdi-995113ec-b2a8-4670-8641-f96b61b67975.json
+++ b/packages/ppbgdi/kibana/dashboard/ppbgdi-995113ec-b2a8-4670-8641-f96b61b67975.json
@@ -4131,7 +4131,7 @@
   "coreMigrationVersion": "8.8.0",
   "created_at": "2026-01-20T09:03:20.535Z",
   "created_by": "u_iNKwjm8SLlUc2MYVzW8-ZccduVX0bI2Y4ltYVm6cTwQ_0",
-  "id": "995113ec-b2a8-4670-8641-f96b61b67975",
+  "id": "ppbgdi-995113ec-b2a8-4670-8641-f96b61b67975",
   "managed": false,
   "references": [
     {

--- a/packages/ppbgdi/manifest.yml
+++ b/packages/ppbgdi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.1
 name: ppbgdi
 title: "PPBGDI"
-version: 2.1.0
+version: 2.1.1
 source:
   license: "Apache-2.0"
 description: "Collect logs and metrics from PPBGDI, via kubernetes or Elastic Agent"


### PR DESCRIPTION
The `elastic-package check` command still shows a "skipped" error for this dashboad:

> 1. file "/root/infra-elastic-integrations/packages/ppbgdi/kibana/dashboard/ppbgdi-995113ec-b2a8-4670-8641-f96b61b67975.json" is invalid: expected filter in dashboard: no filter found and at least one panel does not have a filter (SVR00002)

As far as I understand this is because some of the panels didn't show any data in the exported dashboard, because CloudWatch never reports "zero" on some metrics, it just doesn't produce any data when there is no error of a specific kind to report.

I expect there will be data for all metrics in the production elasticsearch, but I have no idea if this validation error is an issue or not. I can't find any doc about this. Maybe I'll have to re-export the dashboard from the production Kibana.